### PR TITLE
replace "ath10k smallbuffer-patch from freifunkfranken" with upstrem …

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master, next, nightly/* ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, next, nightly/* ]
 
 jobs:
   build:


### PR DESCRIPTION
…solution

This reverts commit 7c33f0620730a4682d525a1bda7ef7e08ee13470 by the recently added
upstream "ath10k-smallbuffers" package.
As this is now a regular package, we can include it to specific (low ram) boards
via the packagelists/profile-packages.txt